### PR TITLE
fixed an issue where the Received event is fired twice because of newline characters

### DIFF
--- a/EventSource4Net/ConnectedState.cs
+++ b/EventSource4Net/ConnectedState.cs
@@ -13,17 +13,21 @@ namespace EventSource4Net
         private static readonly slf4net.ILogger _logger = slf4net.LoggerFactory.GetLogger(typeof(ConnectedState));
 
         private HttpWebResponse mResponse;
+        private IList<string> messageBuffer; //This buffer will contain all strings that when processed will lead to one ServerSentEvent
+
         public EventSourceState State { get { return EventSourceState.OPEN; } }
 
         public ConnectedState(HttpWebResponse resp)
         {
             mResponse = resp;
+            messageBuffer = new List<string>();
         }
 
         public Task<IConnectionState> Run(Action<ServerSentEvent> msgReceived)
         {
             byte[] buffer = new byte[1024*8];
             Stream stream = mResponse.GetResponseStream();
+            
 
             var taskRead = Task<int>.Factory.FromAsync<byte[], int, int>(stream.BeginRead,
                                                                          stream.EndRead, buffer, 0, buffer.Length,
@@ -36,67 +40,31 @@ namespace EventSource4Net
 
                     if (bytesRead > 0) // stream has not reached the end yet
                     {
-                        string text = Encoding.ASCII.GetString(buffer, 0, bytesRead);
-                        //Remove empty carriage returns and line feeds, they don't need to be processed
-                        string[] lines = text.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
-                        ServerSentEvent sse = null;
-                        foreach (string line in lines)
+                        string text = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                        text = text.Replace("\r\n", "\n\n"); //Some servers can send \r\n, so make sure that we convert those
+
+                        while (text.Trim() != string.Empty )
                         {
-                            if (line.StartsWith(":"))
+                            var eventDelimiter = text.IndexOf("\n\n");
+                            if (eventDelimiter != -1)
                             {
-                                // This a comment, just log it.
-                                _logger.Trace("A comment was received: " + line);
+                                //We have the end of a ServerSentEvent, put everything in the buffer and process the event
+                                messageBuffer.Add(text.Substring(0, eventDelimiter));
+                                ProcessEvent(msgReceived);
+                                //Be sure to continue as the server might have sent more data already
+                                text = text.Substring(eventDelimiter+2);
                             }
                             else
                             {
-                                string fieldName = String.Empty;
-                                string fieldValue = String.Empty;
-                                if (line.Contains(':'))
-                                {
-                                    int index = line.IndexOf(':');
-                                    fieldName = line.Substring(0, index);
-                                    fieldValue = line.Substring(index + 1).TrimStart();
-                                }
-                                else
-                                    fieldName = line;
-
-                                if (String.Compare(fieldName, "event", true) == 0)
-                                {
-                                    sse = sse ?? new ServerSentEvent();
-                                    sse.EventType = fieldValue;
-                                }
-                                else if (String.Compare(fieldName, "data", true) == 0)
-                                {
-                                    sse = sse ?? new ServerSentEvent();
-                                    sse.Data = fieldValue + '\n';
-                                }
-                                else if (String.Compare(fieldName, "id", true) == 0)
-                                {
-                                    sse = sse ?? new ServerSentEvent();
-                                    sse.LastEventId = fieldValue;
-                                }
-                                else if (String.Compare(fieldName, "retry", true) == 0)
-                                {
-                                    int parsedRetry;
-                                    if (int.TryParse(fieldValue, out parsedRetry))
-                                    {
-                                        sse = sse ?? new ServerSentEvent();
-                                        sse.Retry = parsedRetry;
-                                    }
-                                }
-                                else
-                                {
-                                    // Ignore this, just log it
-                                    _logger.Warn("A unknown line was received: " + line);
-                                }
+                                //There was no end of ServerSentEvent detected, so add this string to the message buffer
+                                messageBuffer.Add(text);
+                                //We can break out of the loop, the messagebuffer will be dealt with when the server sents \n\n
+                                break;
                             }
                         }
-                        // Dispatch message after all the lines have been processed
-                        if (sse != null)
-                        {
-                            _logger.Trace("Message received");
-                            msgReceived(sse);
-                        }
+                        //Check for edge case where the server sent us the eventDelimiter
+                        if (text == "\n\n")
+                            ProcessEvent(msgReceived);
 
                         return this;
                     }
@@ -108,5 +76,71 @@ namespace EventSource4Net
                 return new DisconnectedState(mResponse.ResponseUri);
             });
         }
+
+        private void ProcessEvent(Action<ServerSentEvent> msgReceived)
+        {
+            ServerSentEvent sse = new ServerSentEvent();
+            foreach (string evt in messageBuffer)
+            {
+                string[] lines = evt.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string line in lines)
+                {
+                    if (line.StartsWith(":"))
+                    {
+                        // This a comment, just log it.
+                        _logger.Trace("A comment was received: " + line);
+                    }
+                    else
+                    {
+                        string fieldName = String.Empty;
+                        string fieldValue = String.Empty;
+                        if (line.Contains(':'))
+                        {
+                            int index = line.IndexOf(':');
+                            fieldName = line.Substring(0, index);
+                            fieldValue = line.Substring(index + 1).TrimStart();
+                        }
+                        else
+                            fieldName = line;
+
+                        if (String.Compare(fieldName, "event", true) == 0)
+                        {
+                            sse = sse ?? new ServerSentEvent();
+                            sse.EventType = fieldValue;
+                        }
+                        else if (String.Compare(fieldName, "data", true) == 0)
+                        {
+                            sse = sse ?? new ServerSentEvent();
+                            sse.Data = fieldValue + '\n';
+                        }
+                        else if (String.Compare(fieldName, "id", true) == 0)
+                        {
+                            sse = sse ?? new ServerSentEvent();
+                            sse.LastEventId = fieldValue;
+                        }
+                        else if (String.Compare(fieldName, "retry", true) == 0)
+                        {
+                            int parsedRetry;
+                            if (int.TryParse(fieldValue, out parsedRetry))
+                            {
+                                sse = sse ?? new ServerSentEvent();
+                                sse.Retry = parsedRetry;
+                            }
+                        }
+                        else
+                        {
+                            // Ignore this, just log it
+                            _logger.Warn("A unknown line was received: " + line);
+                        }
+                    }
+                }
+            }
+            _logger.Trace("Message received");
+            msgReceived(sse);
+            messageBuffer.Clear();
+                    
+        }
+
+
     }
 }


### PR DESCRIPTION
Hi!

I think I have fixed an issue with the code.
A Server sent event terminates with an empty line.

So for example if the server sends the following event: "data: serverdata\n\n", the code would split up the lines and we would get a list of 3 strings:
"data: serverdata" and 2 times the string "\n".

Because of this the code would fire the msgReceived event twice, one for each newline found (line 46 in original code).
If you debug your original sample code, you would see that you would get the same message twice.

I've changed the code to handle this by stripping all the newlines and simply send a msgReceived if the 'sse' object is not null after all the lines have been processed. This way you should only get the event once.

Thanks !!
