### PR TITLE
Aborting web request

### DIFF
--- a/EventSource4Net/ConnectedState.cs
+++ b/EventSource4Net/ConnectedState.cs
@@ -130,6 +130,8 @@ namespace EventSource4Net
                         //stream.Close();
                         //mResponse.Close();
                         //mResponse.Dispose();
+
+                        WebRequester._WebRequest.Abort();
                         return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory);
                     }
                 }

--- a/EventSource4Net/WebRequester.cs
+++ b/EventSource4Net/WebRequester.cs
@@ -9,9 +9,13 @@ namespace EventSource4Net
 {
     class WebRequester : IWebRequester
     {
+        public static WebRequest _WebRequest { get; set; }
+        private HttpWebRequest wreq { get; set; }
+
         public Task<IServerResponse> Get(Uri url)
         {
-            var wreq = (HttpWebRequest)WebRequest.Create(url);
+            _WebRequest = WebRequest.Create(url);
+            wreq = (HttpWebRequest)_WebRequest;
             wreq.Method = "GET";
             wreq.Proxy = null;
 


### PR DESCRIPTION
Without aborting connection android keeps the connection open.
After requesting connection for third time - there were no response from
server. Aborting request in when cancelToken=true fixes the problem.
Tests were done using Xamarin.Forms + Xamarin Android