### PR TITLE
Change status from Open to Close

### DIFF
--- a/EventSource4Net/ConnectedState.cs
+++ b/EventSource4Net/ConnectedState.cs
@@ -46,6 +46,7 @@ namespace EventSource4Net
                         catch (Exception ex)
                         {
                             _logger.Trace(ex, "ConnectedState.Run");
+                            return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory);
                         }
                         if (!cancelToken.IsCancellationRequested)
                         {


### PR DESCRIPTION
There is an issue in ConnectedState.cs. It doesn't change status when stream read exception occurs. 